### PR TITLE
Fixes issue where Ensure DB user check fails when the port value is changed

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -28,6 +28,7 @@
     password: "{{ postgresql.root_password }}"
     role_attr_flags: "SUPERUSER,CREATEROLE,CREATEDB,INHERIT,login"
     state: present
+    port: "{{ postgresql.port }}"
 
 - name: Ensure postgresql is running
   become: yes


### PR DESCRIPTION
Fixes issue #3

When the postgresql.port value is changed you get the following error:

`TASK [Ensure DB user] ********************************************
fatal: [default]: FAILED! => {"changed": false, "failed": true, "msg": "unable to connect to database: could not connect to server: No such file or directory\n\tIs the server running locally and accepting\n\tconnections on Unix domain socket \"/var/run/postgresql/.s.PGSQL.5432\"?\n"}`

This occurs because the postgresql_user gradle core module does not inspect the postgresql configuration and instead opts to connect via the 5432 port as a default. See [here](http://docs.ansible.com/ansible/postgresql_user_module.html) .
